### PR TITLE
handle the redirects manually

### DIFF
--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -66,12 +66,14 @@ class Common {
   static String encodeFormData(Map data, String boundary) {
     final midBoundary = StringBuffer('--$boundary\r\n');
     final endBoundary = StringBuffer('--$boundary--\r\n');
-    final contentDispositionPrefix = StringBuffer('Content-Disposition: form-data; name="');
+    final contentDispositionPrefix =
+        StringBuffer('Content-Disposition: form-data; name="');
     final result = StringBuffer();
     for (final key in data.keys) {
-      result..write(midBoundary)
-      ..write('$contentDispositionPrefix$key"\r\n\r\n')
-      ..write('${data[key]}\r\n');
+      result
+        ..write(midBoundary)
+        ..write('$contentDispositionPrefix$key"\r\n\r\n')
+        ..write('${data[key]}\r\n');
     }
     result.write(endBoundary);
     return result.toString();

--- a/lib/src/requests_plus.dart
+++ b/lib/src/requests_plus.dart
@@ -375,10 +375,9 @@ class RequestsPlus {
         response.headers['location'] = response.headers['location-proxied']!;
         response.headers.remove('location-proxied');
       }
-      final uri = Uri.parse(response.headers['location']!);
-      if (uri.scheme.isEmpty) uri.replace(scheme: Uri.parse(url).scheme);
-      if (uri.host.isEmpty) uri.replace(scheme: Uri.parse(url).host);
-
+      var uri = Uri.parse(response.headers['location']!);
+      if (uri.scheme.isEmpty) uri = uri.replace(scheme: Uri.parse(url).scheme);
+      if (uri.host.isEmpty) uri = uri.replace(host: Uri.parse(url).host);
       return _httpRequest(
         method,
         '${uri.scheme}://${uri.host}${uri.path}',

--- a/lib/src/requests_plus.dart
+++ b/lib/src/requests_plus.dart
@@ -127,7 +127,7 @@ class RequestsPlus {
     String? userName,
     String? password,
   }) {
-        return _httpRequest(
+    return _httpRequest(
       HttpMethod.GET,
       url,
       bodyEncoding: bodyEncoding,

--- a/lib/src/requests_plus.dart
+++ b/lib/src/requests_plus.dart
@@ -127,7 +127,7 @@ class RequestsPlus {
     String? userName,
     String? password,
   }) {
-    return _httpRequest(
+        return _httpRequest(
       HttpMethod.GET,
       url,
       bodyEncoding: bodyEncoding,
@@ -331,21 +331,19 @@ class RequestsPlus {
     bool persistCookies,
     String corsProxyUrl,
     bool followRedirects,
+    HttpMethod method,
+    dynamic json,
+    dynamic body,
+    RequestBodyEncoding bodyEncoding,
+    Map<String, dynamic>? queryParameters,
+    int? port,
+    Map<String, String> headers,
+    int timeoutSeconds,
+    bool verify,
+    bool withCredentials,
+    String? userName,
+    String? password,
   ) async {
-    if (response.headers.containsKey('location-proxied')) {
-      if (followRedirects && response.isRedirect) {
-        final redirectUrl = response.headers['location-proxied']!;
-        return _httpRequest(
-          HttpMethod.GET,
-          redirectUrl,
-          persistCookies: persistCookies,
-          corsProxyUrl: corsProxyUrl,
-        );
-      } else {
-        response.headers['location'] = response.headers['location-proxied']!;
-        response.headers.remove('location-proxied');
-      }
-    }
     if (response.headers.containsKey('set-cookie-proxied')) {
       if (response.headers.containsKey('set-cookie')) {
         response.headers['set-cookie'] =
@@ -369,6 +367,33 @@ class RequestsPlus {
     if (response.hasError) {
       final errorEvent = {'response': response};
       onError.publish(errorEvent);
+    }
+
+    //handle redirects
+    if (followRedirects && response.isRedirect) {
+      if (response.headers.containsKey('location-proxied')) {
+        response.headers['location'] = response.headers['location-proxied']!;
+        response.headers.remove('location-proxied');
+      }
+      final uri = Uri.parse(response.headers['location']!);
+      if (uri.scheme.isEmpty) uri.replace(scheme: Uri.parse(url).scheme);
+      if (uri.host.isEmpty) uri.replace(scheme: Uri.parse(url).host);
+
+      return _httpRequest(
+        method,
+        '${uri.scheme}://${uri.host}${uri.path}',
+        port: uri.port,
+        queryParameters: uri.queryParameters,
+        bodyEncoding: bodyEncoding,
+        timeoutSeconds: timeoutSeconds,
+        persistCookies: persistCookies,
+        verify: verify,
+        withCredentials: withCredentials,
+        corsProxyUrl: corsProxyUrl,
+        followRedirects: followRedirects,
+        userName: userName,
+        password: password,
+      );
     }
 
     return response;
@@ -491,7 +516,7 @@ class RequestsPlus {
       method.toString().split('.').last,
       uri,
     )
-      ..followRedirects = followRedirects
+      ..followRedirects = false //followRedirects
       ..headers.addAll(headers); //little hack to get rid of HttpMethod.
     if ([HttpMethod.POST, HttpMethod.PUT, HttpMethod.PATCH, HttpMethod.DELETE]
             .contains(method) &&
@@ -509,6 +534,18 @@ class RequestsPlus {
       persistCookies,
       corsProxyUrl,
       followRedirects,
+      method,
+      json,
+      body,
+      bodyEncoding,
+      queryParameters,
+      port,
+      headers,
+      timeoutSeconds,
+      verify,
+      withCredentials,
+      userName,
+      password,
     );
   }
 }


### PR DESCRIPTION
Handle redirects inside the lib.
Before, the redirects were done in the HTTP client itself. But it doesn't give the lib the ability to save the cookies from the redirections.
That's why now, it first doesn't follow the redirect, then do the normal cookie parsing and other things and then, if we have a redirect, creates a brand-new request.
